### PR TITLE
Update patches for current Rust

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -14,7 +14,7 @@ export PATH="$PWD/$(echo staging_dir/toolchain-*/bin):$PATH"
 mips-openwrt-linux-gcc -v
 popd
 
-./fetch-and-patch-rust.sh
+./fetch-and-patch-rust.sh --local
 
 set +e
 set +x

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@ rust: nightly
 
 env:
   matrix:
-    - BACKTRACE=no JEMALLOC=dynamic
     - BACKTRACE=no JEMALLOC=no
-    - BACKTRACE=no JEMALLOC=static
-    - BACKTRACE=yes JEMALLOC=dynamic
     - BACKTRACE=yes JEMALLOC=no
-    - BACKTRACE=yes JEMALLOC=static
 
 install:
   - source .travis.install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: rust
 rust: nightly
 
-addons:
-  apt:
-    packages:
-    - llvm-3.4
-    sources:
-    - llvm-toolchain-precise-3.5
-
 env:
   matrix:
     - BACKTRACE=no JEMALLOC=dynamic

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ To cross compile the `std` crate you'll need:
 
 - Rust nightly channel
 - The usual stuff for cross compilation: toolchain and cross compiled C libraries
-- LLVM, in particular both `llvm-mc` and `llc` should be in your PATH
 
 ## How to use
 

--- a/cargo-ify.patch
+++ b/cargo-ify.patch
@@ -25,7 +25,7 @@ index 0000000..e161e91
 +path = "../liblibc"
 diff --git a/src/liballoc/build.rs b/src/liballoc/build.rs
 new file mode 100644
-index 0000000..7fb1260
+index 0000000..ff8a9bd
 --- /dev/null
 +++ b/src/liballoc/build.rs
 @@ -0,0 +1,208 @@
@@ -211,7 +211,7 @@ index 0000000..7fb1260
 +            .arg("--disable-fill")  // see CFG_JEMALLOC_FLAGS at mk/main.mk
 +            .arg(format!("--build={}", ctxt.host()))
 +            .arg(format!("--host={}", ctxt.target()))
-+            .arg(format!("CC={} {}", ctxt.cc(), ctxt.cflags().collect::<Vec<_>>().connect(" ")))
++            .arg(format!("CC={} {}", ctxt.cc(), ctxt.cflags().collect::<Vec<_>>().join(" ")))
 +            .arg(format!("AR={}", ar))
 +            .arg(format!("RANLIB={} s", ar))
 +            .arg(format!("CPPFLAGS=-I {}", ctxt.src().join("../rt/").display()))
@@ -390,10 +390,10 @@ index 0000000..cb7a399
 +path = "../librustc_unicode"
 diff --git a/src/libstd/build.rs b/src/libstd/build.rs
 new file mode 100644
-index 0000000..5f03064
+index 0000000..f80df12
 --- /dev/null
 +++ b/src/libstd/build.rs
-@@ -0,0 +1,320 @@
+@@ -0,0 +1,253 @@
 +#![allow(dead_code)]
 +
 +extern crate gcc;
@@ -428,8 +428,6 @@ index 0000000..5f03064
 +        #[cfg(not(feature = "backtrace"))]
 +        () => {},
 +    }
-+    rustrt_native(ctxt);
-+    morestack(ctxt);
 +    compiler_rt(ctxt);
 +}
 +
@@ -596,7 +594,7 @@ index 0000000..5f03064
 +            .env("AR", ar)
 +            .env("CC", ctxt.cc())
 +            .env("RANLIB", format!("{} s", ar))
-+            .env("CFLAGS", cflags.connect(" "))
++            .env("CFLAGS", cflags.join(" "))
 +            .arg(format!("--target={}", ctxt.target()))
 +            .arg(format!("--host={}", ctxt.host()))
 +            .status_or_panic().success()
@@ -624,71 +622,6 @@ index 0000000..5f03064
 +    println!("cargo:rustc-link-lib=static=backtrace");
 +}
 +
-+/// Build `librustrt_native`
-+// See `mk/rt.mk`
-+fn rustrt_native(ctxt: &Ctxt) {
-+    let dst = ctxt.dst();
-+    let src = ctxt.src();
-+
-+    assert! {
-+        Command::new("llc")
-+            .arg("-filetype=obj")
-+            .arg(format!("-mtriple={}", ctxt.target()))
-+            .arg("-relocation-model=pic")
-+            .arg("-o").arg(dst.join("rust_try.o"))
-+            .arg(src.join("../rt/rust_try.ll"))
-+            .status_or_panic().success()
-+    }
-+
-+    let mut cmd = Command::new(ctxt.cc());
-+    for flag in ctxt.cflags() {
-+        cmd.arg(flag);
-+    }
-+
-+    assert! {
-+        cmd
-+            .arg(src.join(format!("../rt/arch/{}/record_sp.S", ctxt.arch())))
-+            .arg("-c")
-+            .arg("-o").arg(dst.join("record_sp.o"))
-+            .status_or_panic().success()
-+    }
-+
-+    assert! {
-+        Command::new(ctxt.ar())
-+            .arg("crus")
-+            .arg(dst.join("librustrt_native.a"))
-+            .arg(dst.join("rust_try.o"))
-+            .arg(dst.join("record_sp.o"))
-+            .status_or_panic().success()
-+    }
-+
-+    println!("cargo:rustc-link-lib=static=rustrt_native");
-+}
-+
-+/// Build `libmorestack.a`
-+fn morestack(ctxt: &Ctxt) {
-+    let dst = ctxt.dst();
-+
-+    assert! {
-+        Command::new("llvm-mc")
-+            .arg("-assemble")
-+            .arg("-relocation-model=pic")
-+            .arg("-filetype=obj")
-+            .arg(format!("-triple={}", ctxt.target()))
-+            .arg("-o").arg(dst.join("morestack.o"))
-+            .arg(ctxt.src().join(format!("../rt/arch/{}/morestack.S", ctxt.arch())))
-+            .status_or_panic().success()
-+    }
-+
-+    assert! {
-+        Command::new(ctxt.ar())
-+            .arg("crus")
-+            .arg(dst.join("libmorestack.a"))
-+            .arg(dst.join("morestack.o"))
-+            .status_or_panic().success()
-+    }
-+}
-+
 +/// Build `libcompiler_rt.a`
 +// We don't really need this to compile libstd, but most binaries that depend on libstd will try
 +// to link to this library
@@ -703,7 +636,7 @@ index 0000000..5f03064
 +            .arg(format!("CC={}", ctxt.cc()))
 +            .arg(format!("AR={}", ar))
 +            .arg(format!("RANLIB={} s", ar))
-+            .arg(format!("CFLAGS={}", ctxt.cflags().collect::<Vec<_>>().connect(" ")))
++            .arg(format!("CFLAGS={}", ctxt.cflags().collect::<Vec<_>>().join(" ")))
 +            .arg("-C").arg(src)
 +            .arg(format!("ProjSrcRoot={}", src.display()))
 +            .arg(format!("ProjObjRoot={}", build_dir.display()))

--- a/fetch-and-patch-rust.sh
+++ b/fetch-and-patch-rust.sh
@@ -7,6 +7,18 @@
 set -e
 set -x
 
+if [ $1 == "--local" ]; then
+    LOCAL=1
+fi
+
+fetch () {
+    if [ "$LOCAL" = 1 ]; then
+        cat "$1"
+    else
+        curl -s https://raw.githubusercontent.com/japaric/std-with-cargo/master/"$1"
+    fi
+}
+
 # find out `rustc` version
 HASH=$(rustc -Vv | sed -n 3p | cut -d ' ' -f2)
 
@@ -40,7 +52,7 @@ rm ${HASH}.zip
 
 # patch
 cd ..
-curl -s https://raw.githubusercontent.com/japaric/std-with-cargo/master/cargo-ify.patch | patch -p1
-curl -s https://raw.githubusercontent.com/japaric/std-with-cargo/master/optional-backtrace.patch | patch -p1
-curl -s https://raw.githubusercontent.com/japaric/std-with-cargo/master/optional-jemalloc.patch | patch -p1
-curl -s https://raw.githubusercontent.com/japaric/std-with-cargo/master/remove-mno-compact-eh-flag.patch | patch -p1
+fetch cargo-ify.patch | patch -p1
+fetch optional-backtrace.patch | patch -p1
+fetch optional-jemalloc.patch | patch -p1
+fetch remove-mno-compact-eh-flag.patch | patch -p1

--- a/fetch-and-patch-rust.sh
+++ b/fetch-and-patch-rust.sh
@@ -54,5 +54,4 @@ rm ${HASH}.zip
 cd ..
 fetch cargo-ify.patch | patch -p1
 fetch optional-backtrace.patch | patch -p1
-fetch optional-jemalloc.patch | patch -p1
 fetch remove-mno-compact-eh-flag.patch | patch -p1

--- a/fetch-and-patch-rust.sh
+++ b/fetch-and-patch-rust.sh
@@ -13,7 +13,7 @@ fi
 
 fetch () {
     if [ "$LOCAL" = 1 ]; then
-        cat "$1"
+        cat ../"$1"
     else
         curl -s https://raw.githubusercontent.com/japaric/std-with-cargo/master/"$1"
     fi

--- a/optional-backtrace.patch
+++ b/optional-backtrace.patch
@@ -1,9 +1,9 @@
 diff --git a/src/libstd/sys/unix/mod.rs b/src/libstd/sys/unix/mod.rs
-index c1a4e8c..ae21c02 100644
+index bbed42c..388d2fc 100644
 --- a/src/libstd/sys/unix/mod.rs
 +++ b/src/libstd/sys/unix/mod.rs
-@@ -28,7 +28,21 @@ use ops::Neg;
- #[cfg(target_os = "nacl")]      pub use os::nacl as platform;
+@@ -27,7 +27,21 @@ use ops::Neg;
+ #[cfg(target_os = "netbsd")]    pub use os::netbsd as platform;
  #[cfg(target_os = "openbsd")]   pub use os::openbsd as platform;
  
 +#[cfg(feature = "backtrace")]


### PR DESCRIPTION
First: this project is pretty awesome.

I've updated cargo-ify.patch and optional-backtrace.patch to apply cleanly to current Rust master and compile successfully (at least when native-building on x86_64). Fortunately that consists primarily of removing code.

I didn't update optional-jemalloc.patch, because the entirety of the code that's being patched got removed in rust-lang/rust#27400. But as a result of that change, you can now force the use of the system allocator using just standard (unstable) Rust by adding

``` rust
#![feature(alloc_system)]
extern crate alloc_system;
```

This doesn't support dynamically-linking jemalloc, though. I imagine the current patch could be ported to the new alloc_jemalloc crate.

remove-mno-compact-eh-flag.patch still applies cleanly, so it's unchanged.

I am not actually able to (native-)build a _project_ depending on my resulting libstd using cargo; I get duplicate definitions of all the lang-items, even if I attempt to use `#![no_std]` and an explicit `extern crate std`. But I'm not sure that's related.
